### PR TITLE
fix: correct defaultValue from attributes

### DIFF
--- a/library/src/main/java/com/pavelsikun/seekbarpreference/MaterialSeekBarController.java
+++ b/library/src/main/java/com/pavelsikun/seekbarpreference/MaterialSeekBarController.java
@@ -86,7 +86,7 @@ public class MaterialSeekBarController implements TextWatcher, DiscreteSeekBar.O
                 mMaxValue = a.getInt(com.pavelsikun.seekbarpreference.R.styleable.SeekBarPreference_msbp_maxValue, DEFAULT_MAX_VALUE);
                 mInterval = a.getInt(com.pavelsikun.seekbarpreference.R.styleable.SeekBarPreference_msbp_interval, DEFAULT_INTERVAL);
 
-                mCurrentValue = attrs.getAttributeIntValue(android.R.attr.defaultValue, DEFAULT_CURRENT_VALUE);
+                mCurrentValue = attrs.getAttributeIntValue("http://schemas.android.com/apk/res/android", "defaultValue", DEFAULT_CURRENT_VALUE);
 
                 mTitle = a.getString(com.pavelsikun.seekbarpreference.R.styleable.SeekBarPreference_msbp_title);
                 mSummary = a.getString(com.pavelsikun.seekbarpreference.R.styleable.SeekBarPreference_msbp_summary);


### PR DESCRIPTION
Your way of extracting the value from attributes was incorrect. It is a simple, but working solution.
For reference look at this SO answer:
http://stackoverflow.com/questions/7896615/android-how-to-get-value-of-an-attribute-in-code
