### PR TITLE
Fixed number of steps in seekbar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
 

--- a/library/src/main/java/com/pavelsikun/seekbarpreference/PreferenceControllerDelegate.java
+++ b/library/src/main/java/com/pavelsikun/seekbarpreference/PreferenceControllerDelegate.java
@@ -154,17 +154,6 @@ class PreferenceControllerDelegate implements SeekBar.OnSeekBarChangeListener, V
     public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
         int newValue = minValue + (progress * interval);
 
-        if (interval != 1 && newValue % interval != 0) {
-            newValue = Math.round(((float) newValue) / interval) * interval;
-        }
-
-        if (newValue > maxValue) {
-            newValue = maxValue;
-        }
-        else if (newValue < minValue) {
-            newValue = minValue;
-        }
-
         if (changeValueListener != null) {
             if (!changeValueListener.onChange(newValue)) {
                 return;

--- a/library/src/main/java/com/pavelsikun/seekbarpreference/PreferenceControllerDelegate.java
+++ b/library/src/main/java/com/pavelsikun/seekbarpreference/PreferenceControllerDelegate.java
@@ -91,8 +91,9 @@ class PreferenceControllerDelegate implements SeekBar.OnSeekBarChangeListener, V
             TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.SeekBarPreference);
             try {
                 minValue = a.getInt(R.styleable.SeekBarPreference_msbp_minValue, DEFAULT_MIN_VALUE);
-                maxValue = a.getInt(R.styleable.SeekBarPreference_msbp_maxValue, DEFAULT_MAX_VALUE);
                 interval = a.getInt(R.styleable.SeekBarPreference_msbp_interval, DEFAULT_INTERVAL);
+                int saved_maxValue = a.getInt(R.styleable.SeekBarPreference_msbp_maxValue, DEFAULT_MAX_VALUE);
+                maxValue = (saved_maxValue - minValue) / interval;
                 dialogEnabled = a.getBoolean(R.styleable.SeekBarPreference_msbp_dialogEnabled, DEFAULT_DIALOG_ENABLED);
 
                 measurementUnit = a.getString(R.styleable.SeekBarPreference_msbp_measurementUnit);
@@ -151,7 +152,7 @@ class PreferenceControllerDelegate implements SeekBar.OnSeekBarChangeListener, V
 
     @Override
     public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-        int newValue = progress + minValue;
+        int newValue = minValue + (progress * interval);
 
         if (interval != 1 && newValue % interval != 0) {
             newValue = Math.round(((float) newValue) / interval) * interval;


### PR DESCRIPTION
Seekbar is not designed to take a non-zero minimum or a different step size. This is a solution to that by changing the way max is used for progress.
