### PR TITLE
FIX: RecyclerView does not create multiple seek bars

### DIFF
--- a/library/src/main/java/com/pavelsikun/seekbarpreference/SeekBarPreferenceView.java
+++ b/library/src/main/java/com/pavelsikun/seekbarpreference/SeekBarPreferenceView.java
@@ -40,12 +40,8 @@ public class SeekBarPreferenceView extends FrameLayout implements View.OnClickLi
     private void init(AttributeSet attrs) {
         controllerDelegate = new PreferenceControllerDelegate(getContext(), true);
         controllerDelegate.loadValuesFromXml(attrs);
-    }
 
-    @Override
-    protected void onAttachedToWindow() {
-        super.onAttachedToWindow();
-        View view = inflate(getContext(), R.layout.seekbar_view_layout, this);
+        final View view = inflate(getContext(), R.layout.seekbar_view_layout, this);
         controllerDelegate.onBind(view);
     }
 


### PR DESCRIPTION
I moved the inflate and bind from onAttachedToWindow() method to the init(...) method. This works correctly in my app in a PreferenceFragment and also inside a RecyclerView.