### PR TITLE
seekbar now fills all available space after value text is drawn.

### DIFF
--- a/library/src/main/res/layout/seekbar_view_layout.xml
+++ b/library/src/main/res/layout/seekbar_view_layout.xml
@@ -27,30 +27,28 @@
         android:textColor="?android:attr/textColorSecondary"
         android:maxLines="10"/>
 
-    <RelativeLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="50dp"
-        android:gravity="center_vertical">
+        android:layout_marginRight="16dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
 
         <SeekBar
             android:id="@+id/seekbar"
-            android:layout_centerVertical="true"
-            android:layout_alignParentLeft="true"
-            android:layout_width="@dimen/msbp_seekbar_width"
-            android:layout_height="wrap_content" />
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_vertical"/>
 
         <LinearLayout
             android:id="@+id/value_holder"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_alignParentRight="true"
-            android:layout_toRightOf="@id/seekbar"
-
-            android:layout_centerVertical="true"
-            android:gravity="center"
             android:clickable="true"
             android:background="?attr/selectableItemBackgroundBorderless"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:gravity="center_vertical">
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -88,6 +86,6 @@
 
         </LinearLayout>
 
-    </RelativeLayout>
+    </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
fix for issue 50
[Issue 50](https://github.com/MrBIMC/MaterialSeekBarPreference/issues/50)

priority is always given to the value first. Then seek bar is allowed to fill the remainder. 