### PR TITLE
Plurals support, dialog styling and localization support, minSdk=14, tools to 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Either of way, View/Preference provides next methods to modify and manage it fro
     public void setCurrentValue(int currentValue);
 
     public String getMeasurementUnit();
-    public void setMeasurementUnit(String measurementUnit);
+    public void setMeasurementUnit(String unit);
 
     public void setDialogEnabled(boolean dialogEnabled);
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,16 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 26
         versionCode 13
         versionName "2.3.0"
+        vectorDrawables.useSupportLibrary = true
     }
 
     lintOptions {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 23
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 13
         versionName "2.3.0"
     }
@@ -17,8 +17,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:preference-v7:23.4.0'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:preference-v7:26.1.0'
 }
 
 ext {

--- a/library/src/main/java/com/pavelsikun/seekbarpreference/CustomValueDialog.java
+++ b/library/src/main/java/com/pavelsikun/seekbarpreference/CustomValueDialog.java
@@ -2,8 +2,13 @@ package com.pavelsikun.seekbarpreference;
 
 import android.app.Dialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.res.TypedArray;
+import android.content.res.XmlResourceParser;
+import android.support.annotation.StringRes;
 import android.support.v7.app.AlertDialog;
+import android.text.TextUtils;
+import android.util.AttributeSet;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
@@ -20,57 +25,103 @@ class CustomValueDialog {
 
     private final String TAG = getClass().getSimpleName();
 
+    private static final int DEFAULT_CANCEL_RES_ID = android.R.string.cancel;
+    private static final int DEFAULT_OK_RES_ID = android.R.string.ok;
+    private static final int DEFAULT_TITLE_RES_ID = R.string.enter_custom_value;
+
     private Dialog dialog;
     private EditText customValueView;
 
     private int minValue, maxValue, currentValue;
     private PersistValueListener persistValueListener;
 
+    private String okText = null;
+    private String cancelText = null;
+    private String titleText = null;
+
     CustomValueDialog(Context context, int theme, int minValue, int maxValue, int currentValue) {
         this.minValue = minValue;
         this.maxValue = maxValue;
         this.currentValue = currentValue;
 
+        if (theme != 0) {
+            TypedArray a = null;
+            try {
+                a = context.obtainStyledAttributes(theme, R.styleable.SeekBarPreference);
+                int cancelId = a.getResourceId(R.styleable.SeekBarPreference_msbp_dialogCancel, 0);
+                if (cancelId == 0) {
+                    cancelText = a.getString(R.styleable.SeekBarPreference_msbp_dialogCancel);
+                    if (cancelText == null)
+                        cancelText = context.getString(DEFAULT_CANCEL_RES_ID);
+                } else
+                    cancelText = context.getString(cancelId);
+
+                int okId = a.getResourceId(R.styleable.SeekBarPreference_msbp_dialogOk, 0);
+                if (okId == 0) {
+                    okText = a.getString(R.styleable.SeekBarPreference_msbp_dialogOk);
+                    if (okText == null)
+                        okText = context.getString(DEFAULT_OK_RES_ID);
+                } else
+                    okText = context.getString(okId);
+
+                int titleId = a.getResourceId(R.styleable.SeekBarPreference_msbp_dialogTitle, 0);
+                if (titleId == 0) {
+                    titleText = a.getString(R.styleable.SeekBarPreference_msbp_dialogTitle);
+                    if (titleText == null)
+                        titleText = context.getString(DEFAULT_TITLE_RES_ID);
+                } else
+                    titleText = context.getString(titleId);
+
+            } finally {
+                if (a != null) a.recycle();
+            }
+
+        }
         init(new AlertDialog.Builder(context, theme));
     }
 
     private void init(AlertDialog.Builder dialogBuilder) {
         View dialogView = LayoutInflater.from(dialogBuilder.getContext()).inflate(R.layout.value_selector_dialog, null);
-        dialog = dialogBuilder.setView(dialogView).create();
 
-        TextView minValueView = (TextView) dialogView.findViewById(R.id.minValue);
-        TextView maxValueView = (TextView) dialogView.findViewById(R.id.maxValue);
-        customValueView = (EditText) dialogView.findViewById(R.id.customValue);
+        TextView minValueView = dialogView.findViewById(R.id.minValue);
+        TextView maxValueView = dialogView.findViewById(R.id.maxValue);
+        customValueView = dialogView.findViewById(R.id.customValue);
 
         minValueView.setText(String.valueOf(minValue));
         maxValueView.setText(String.valueOf(maxValue));
         customValueView.setHint(String.valueOf(currentValue));
 
-        LinearLayout colorView = (LinearLayout) dialogView.findViewById(R.id.dialog_color_area);
+        if (!TextUtils.isEmpty(titleText)) {
+            TextView titleView = dialogView.findViewById(R.id.dialog_title);
+            if (titleView != null)
+                titleView.setText(titleText);
+        }
+
+        LinearLayout colorView = dialogView.findViewById(R.id.dialog_color_area);
         colorView.setBackgroundColor(fetchAccentColor(dialogBuilder.getContext()));
 
-        Button applyButton = (Button) dialogView.findViewById(R.id.btn_apply);
-        Button cancelButton = (Button) dialogView.findViewById(R.id.btn_cancel);
+        if (!TextUtils.isEmpty(okText))
+            dialogBuilder.setPositiveButton(okText, new Dialog.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    tryApply();
+                }
+            });
 
-        applyButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                tryApply();
-            }
-        });
-
-        cancelButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                dialog.dismiss();
-            }
-        });
+        if (!TextUtils.isEmpty(cancelText))
+            dialogBuilder.setNegativeButton(cancelText, new Dialog.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    dialog.dismiss();
+                }
+            });
+        dialog = dialogBuilder.setView(dialogView).create();
     }
 
     private int fetchAccentColor(Context context) {
         TypedValue typedValue = new TypedValue();
 
-        TypedArray a = context.obtainStyledAttributes(typedValue.data, new int[] { R.attr.colorAccent });
+        TypedArray a = context.obtainStyledAttributes(typedValue.data, new int[]{R.attr.colorAccent});
         int color = a.getColor(0, 0);
         a.recycle();
 
@@ -95,20 +146,18 @@ class CustomValueDialog {
                 Log.e(TAG, "wrong input( > than required): " + customValueView.getText().toString());
                 notifyWrongInput();
                 return;
-            }
-            else if (value < minValue) {
+            } else if (value < minValue) {
                 Log.e(TAG, "wrong input( < then required): " + customValueView.getText().toString());
                 notifyWrongInput();
                 return;
             }
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             Log.e(TAG, "worng input(non-integer): " + customValueView.getText().toString());
             notifyWrongInput();
             return;
         }
 
-        if(persistValueListener != null) {
+        if (persistValueListener != null) {
             persistValueListener.persistInt(value);
             dialog.dismiss();
         }

--- a/library/src/main/java/com/pavelsikun/seekbarpreference/PreferenceControllerDelegate.java
+++ b/library/src/main/java/com/pavelsikun/seekbarpreference/PreferenceControllerDelegate.java
@@ -2,6 +2,9 @@ package com.pavelsikun.seekbarpreference;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.support.annotation.Nullable;
+import android.support.annotation.PluralsRes;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
@@ -10,330 +13,447 @@ import android.widget.LinearLayout;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
+import java.util.regex.Pattern;
+
 /**
  * Created by Pavel Sikun on 28.05.16.
  */
 
+@SuppressWarnings("WeakerAccess")
 class PreferenceControllerDelegate implements SeekBar.OnSeekBarChangeListener, View.OnClickListener {
-
-    private final String TAG = getClass().getSimpleName();
-
-    private static final int DEFAULT_CURRENT_VALUE = 50;
-    private static final int DEFAULT_MIN_VALUE = 0;
-    private static final int DEFAULT_MAX_VALUE = 100;
-    private static final int DEFAULT_INTERVAL = 1;
-    private static final boolean DEFAULT_DIALOG_ENABLED = true;
-    private static final boolean DEFAULT_IS_ENABLED = true;
-
-    private static final int DEFAULT_DIALOG_STYLE = R.style.MSB_Dialog_Default;
-
-    private int maxValue;
-    private int minValue;
-    private int interval;
-    private int currentValue;
-    private String measurementUnit;
-    private boolean dialogEnabled;
-
-    private int dialogStyle;
-
-    private TextView valueView;
-    private SeekBar seekBarView;
-    private TextView measurementView;
-    private LinearLayout valueHolderView;
-    private FrameLayout bottomLineView;
-
-    //view stuff
-    private TextView titleView, summaryView;
-    private String title;
-    private String summary;
-    private boolean isEnabled;
-
-    //controller stuff
-    private boolean isView = false;
-    private Context context;
-    private ViewStateListener viewStateListener;
-    private PersistValueListener persistValueListener;
-    private ChangeValueListener changeValueListener;
-
-    interface ViewStateListener {
-        boolean isEnabled();
-        void setEnabled(boolean enabled);
-    }
-
-    PreferenceControllerDelegate(Context context, Boolean isView) {
-        this.context = context;
-        this.isView = isView;
-    }
-
-    void setPersistValueListener(PersistValueListener persistValueListener) {
-        this.persistValueListener = persistValueListener;
-    }
-
-    void setViewStateListener(ViewStateListener viewStateListener) {
-        this.viewStateListener = viewStateListener;
-    }
-
-    void setChangeValueListener(ChangeValueListener changeValueListener) {
-        this.changeValueListener = changeValueListener;
-    }
-
-    void loadValuesFromXml(AttributeSet attrs) {
-        if(attrs == null) {
-            currentValue = DEFAULT_CURRENT_VALUE;
-            minValue = DEFAULT_MIN_VALUE;
-            maxValue = DEFAULT_MAX_VALUE;
-            interval = DEFAULT_INTERVAL;
-            dialogEnabled = DEFAULT_DIALOG_ENABLED;
-
-            isEnabled = DEFAULT_IS_ENABLED;
-        }
-        else {
-            TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.SeekBarPreference);
-            try {
-                minValue = a.getInt(R.styleable.SeekBarPreference_msbp_minValue, DEFAULT_MIN_VALUE);
-                interval = a.getInt(R.styleable.SeekBarPreference_msbp_interval, DEFAULT_INTERVAL);
-                int saved_maxValue = a.getInt(R.styleable.SeekBarPreference_msbp_maxValue, DEFAULT_MAX_VALUE);
-                maxValue = (saved_maxValue - minValue) / interval;
-                dialogEnabled = a.getBoolean(R.styleable.SeekBarPreference_msbp_dialogEnabled, DEFAULT_DIALOG_ENABLED);
-
-                measurementUnit = a.getString(R.styleable.SeekBarPreference_msbp_measurementUnit);
-                currentValue = attrs.getAttributeIntValue("http://schemas.android.com/apk/res/android", "defaultValue", DEFAULT_CURRENT_VALUE);
-
-//                TODO make it work:
-//                dialogStyle = a.getInt(R.styleable.SeekBarPreference_msbp_interval, DEFAULT_DIALOG_STYLE);
-
-                dialogStyle = DEFAULT_DIALOG_STYLE;
-
-                if(isView) {
-                    title = a.getString(R.styleable.SeekBarPreference_msbp_view_title);
-                    summary = a.getString(R.styleable.SeekBarPreference_msbp_view_summary);
-                    currentValue = a.getInt(R.styleable.SeekBarPreference_msbp_view_defaultValue, DEFAULT_CURRENT_VALUE);
-
-                    isEnabled = a.getBoolean(R.styleable.SeekBarPreference_msbp_view_enabled, DEFAULT_IS_ENABLED);
-                }
-            }
-            finally {
-                a.recycle();
-            }
-        }
-    }
-
-
-    void onBind(View view) {
-
-        if(isView) {
-            titleView = (TextView) view.findViewById(android.R.id.title);
-            summaryView = (TextView) view.findViewById(android.R.id.summary);
-
-            titleView.setText(title);
-            summaryView.setText(summary);
-        }
-
-        view.setClickable(false);
-
-        seekBarView = (SeekBar) view.findViewById(R.id.seekbar);
-        measurementView = (TextView) view.findViewById(R.id.measurement_unit);
-        valueView = (TextView) view.findViewById(R.id.seekbar_value);
-
-        setMaxValue(maxValue);
-        seekBarView.setOnSeekBarChangeListener(this);
-
-        measurementView.setText(measurementUnit);
-
-        setCurrentValue(currentValue);
-        valueView.setText(String.valueOf(currentValue));
-
-        bottomLineView = (FrameLayout) view.findViewById(R.id.bottom_line);
-        valueHolderView = (LinearLayout) view.findViewById(R.id.value_holder);
-
-        setDialogEnabled(dialogEnabled);
-        setEnabled(isEnabled(), true);
-    }
-
-    @Override
-    public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-        int newValue = minValue + (progress * interval);
-
-        if (changeValueListener != null) {
-            if (!changeValueListener.onChange(newValue)) {
-                return;
-            }
-        }
-        currentValue = newValue;
-        valueView.setText(String.valueOf(newValue));
-    }
-
-    @Override
-    public void onStartTrackingTouch(SeekBar seekBar) {
-    }
-
-    @Override
-    public void onStopTrackingTouch(SeekBar seekBar) {
-        setCurrentValue(currentValue);
-    }
-
-    @Override
-    public void onClick(final View v) {
-        new CustomValueDialog(context, dialogStyle, minValue, maxValue, currentValue)
-                .setPersistValueListener(new PersistValueListener() {
-                    @Override
-                    public boolean persistInt(int value) {
-                        setCurrentValue(value);
-                        seekBarView.setOnSeekBarChangeListener(null);
-                        seekBarView.setProgress(currentValue - minValue);
-                        seekBarView.setOnSeekBarChangeListener(PreferenceControllerDelegate.this);
-
-                        valueView.setText(String.valueOf(currentValue));
-                        return true;
-                    }
-                })
-                .show();
-    }
-
-
-    String getTitle() {
-        return title;
-    }
-
-    void setTitle(String title) {
-        this.title = title;
-        if(titleView != null) {
-            titleView.setText(title);
-        }
-    }
-
-    String getSummary() {
-        return summary;
-    }
-
-    void setSummary(String summary) {
-        this.summary = summary;
-        if(seekBarView != null) {
-            summaryView.setText(summary);
-        }
-    }
-
-    boolean isEnabled() {
-        if(!isView && viewStateListener != null) {
-            return viewStateListener.isEnabled();
-        }
-        else return isEnabled;
-    }
-
-    void setEnabled(boolean enabled, boolean viewsOnly) {
-        Log.d(TAG, "setEnabled = " + enabled);
-        isEnabled = enabled;
-
-        if(viewStateListener != null && !viewsOnly) {
-            viewStateListener.setEnabled(enabled);
-        }
-
-        if(seekBarView != null) { //theoretically might not always work
-            Log.d(TAG, "view is disabled!");
-            seekBarView.setEnabled(enabled);
-            valueView.setEnabled(enabled);
-            valueHolderView.setClickable(enabled);
-            valueHolderView.setEnabled(enabled);
-
-            measurementView.setEnabled(enabled);
-            bottomLineView.setEnabled(enabled);
-
-            if(isView) {
-                titleView.setEnabled(enabled);
-                summaryView.setEnabled(enabled);
-            }
-        }
-
-    }
-
-    void setEnabled(boolean enabled) {
-        setEnabled(enabled, false);
-    }
-
-    int getMaxValue() {
-        return maxValue;
-    }
-
-    void setMaxValue(int maxValue) {
-        this.maxValue = maxValue;
-
-        if (seekBarView != null) {
-            if (minValue <= 0 && maxValue >= 0) {
-                seekBarView.setMax(maxValue - minValue);
-            }
-            else {
-                seekBarView.setMax(maxValue);
-            }
-
-            seekBarView.setProgress(currentValue - minValue);
-        }
-    }
-
-    int getMinValue() {
-        return minValue;
-    }
-
-    public void setMinValue(int minValue) {
-        this.minValue = minValue;
-        setMaxValue(maxValue);
-    }
-
-    int getInterval() {
-        return interval;
-    }
-
-    void setInterval(int interval) {
-        this.interval = interval;
-    }
-
-    int getCurrentValue() {
-        return currentValue;
-    }
-
-    void setCurrentValue(int value) {
-        if(value < minValue) value = minValue;
-        if(value > maxValue) value = maxValue;
-
-        if (changeValueListener != null) {
-            if (!changeValueListener.onChange(value)) {
-                return;
-            }
-        }
-        currentValue = value;
-        if(seekBarView != null)
-            seekBarView.setProgress(currentValue - minValue);
-
-        if(persistValueListener != null) {
-            persistValueListener.persistInt(value);
-        }
-    }
-
-    String getMeasurementUnit() {
-        return measurementUnit;
-    }
-
-    void setMeasurementUnit(String measurementUnit) {
-        this.measurementUnit = measurementUnit;
-        if(measurementView != null) {
-            measurementView.setText(measurementUnit);
-        }
-    }
-
-    boolean isDialogEnabled() {
-        return dialogEnabled;
-    }
-
-    void setDialogEnabled(boolean dialogEnabled) {
-        this.dialogEnabled = dialogEnabled;
-
-        if(valueHolderView != null && bottomLineView != null) {
-            valueHolderView.setOnClickListener(dialogEnabled ? this : null);
-            valueHolderView.setClickable(dialogEnabled);
-            bottomLineView.setVisibility(dialogEnabled ? View.VISIBLE : View.INVISIBLE);
-        }
-    }
-
-    void setDialogStyle(int dialogStyle) {
-        this.dialogStyle = dialogStyle;
-    }
+	private static final boolean DEBUG = true && BuildConfig.DEBUG;
+	public static final String NS_ANDROID = "http://schemas.android.com/apk/res/android";
+	private final String TAG = getClass().getSimpleName();
+
+	private static final int DEFAULT_CURRENT_VALUE = 50;
+	private static final int DEFAULT_MIN_VALUE = 0;
+	private static final int DEFAULT_MAX_VALUE = 100;
+	private static final int DEFAULT_INTERVAL = 1;
+	private static final boolean DEFAULT_DIALOG_ENABLED = true;
+	private static final boolean DEFAULT_IS_ENABLED = true;
+
+	private static final int DEFAULT_DIALOG_STYLE = R.style.MSB_Dialog_Default;
+	private static final Pattern FORMAT_PATTERN = Pattern.compile(".*(?:[^%]%)[dhs].*");
+	private int maxValue;
+	private int seekMaxValue;
+	private int minValue;
+	private int interval;
+	private int currentValue;
+	private String unit;
+	private boolean unitIsFormat;
+	@PluralsRes
+	private int summaryPluralResId;
+	@PluralsRes
+	private int unitPluralsResId;
+	private boolean dialogEnabled;
+
+	private int dialogStyle;
+
+	private TextView valueView;
+	private SeekBar seekBarView;
+	private LinearLayout valueHolderView;
+	private FrameLayout bottomLineView;
+
+	//view stuff
+	private TextView titleView, summaryView;
+	private String title;
+	private String summary;
+	private boolean isEnabled;
+
+	//controller stuff
+	private boolean isView = false;
+	private Context context;
+	private ViewStateListener viewStateListener;
+	private PersistValueListener persistValueListener;
+	private ChangeValueListener changeValueListener;
+
+	interface ViewStateListener {
+		boolean isEnabled();
+
+		void setEnabled(boolean enabled);
+	}
+
+	PreferenceControllerDelegate(Context context, Boolean isView) {
+		this.context = context;
+		this.isView = isView;
+	}
+
+	void setPersistValueListener(PersistValueListener persistValueListener) {
+		this.persistValueListener = persistValueListener;
+	}
+
+	void setViewStateListener(ViewStateListener viewStateListener) {
+		this.viewStateListener = viewStateListener;
+	}
+
+	void setChangeValueListener(ChangeValueListener changeValueListener) {
+		this.changeValueListener = changeValueListener;
+	}
+
+	void loadValuesFromXml(AttributeSet attrs) {
+		if (attrs == null) {
+			currentValue = DEFAULT_CURRENT_VALUE;
+			minValue = DEFAULT_MIN_VALUE;
+			maxValue = DEFAULT_MAX_VALUE;
+			interval = DEFAULT_INTERVAL;
+			dialogEnabled = DEFAULT_DIALOG_ENABLED;
+			summaryPluralResId = 0;
+			unitPluralsResId = 0;
+
+			isEnabled = DEFAULT_IS_ENABLED;
+		} else {
+			TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.SeekBarPreference);
+			try {
+				minValue = a.getInt(R.styleable.SeekBarPreference_msbp_minValue, DEFAULT_MIN_VALUE);
+				maxValue = a.getInt(R.styleable.SeekBarPreference_msbp_maxValue, DEFAULT_MAX_VALUE);
+				interval = a.getInt(R.styleable.SeekBarPreference_msbp_interval, DEFAULT_INTERVAL);
+				seekMaxValue = (maxValue - minValue) / interval;
+
+				dialogEnabled = a.getBoolean(R.styleable.SeekBarPreference_msbp_dialogEnabled, DEFAULT_DIALOG_ENABLED);
+
+				// plurals support for units
+				unitPluralsResId = a.getResourceId(R.styleable.SeekBarPreference_msbp_measurementUnit, 0);
+				if (unitPluralsResId != 0) {
+					String unitPluralResType = context.getResources().getResourceTypeName(unitPluralsResId);
+					if (unitPluralResType.equalsIgnoreCase("plurals")) {
+						unit = null;
+						unitIsFormat = true;
+					} else {
+						// not a plural, string, probably, won't check.
+						unitPluralsResId = 0;
+					}
+				}
+
+				if (unitPluralsResId == 0) {
+					setUnit(a.getString(R.styleable.SeekBarPreference_msbp_measurementUnit));
+					unitIsFormat = isFormatString(unit);
+				}
+
+				currentValue = attrs.getAttributeIntValue(NS_ANDROID, "defaultValue", DEFAULT_CURRENT_VALUE);
+
+				dialogStyle = a.getResourceId(R.styleable.SeekBarPreference_msbp_dialogStyle, DEFAULT_DIALOG_STYLE);
+
+				if (isView) {
+					title = a.getString(R.styleable.SeekBarPreference_msbp_view_title);
+
+					currentValue = a.getInt(R.styleable.SeekBarPreference_msbp_view_defaultValue, DEFAULT_CURRENT_VALUE);
+
+					isEnabled = a.getBoolean(R.styleable.SeekBarPreference_msbp_view_enabled, DEFAULT_IS_ENABLED);
+
+					// following lines are dealing with plurals resource for summary
+					// plurals resource may be specified in "msbp_view_summary"
+					// or "android:summary" (takes precedence)
+
+					// try "android:summary" for reference first
+					int id = attrs.getAttributeResourceValue(NS_ANDROID, "summary", 0);
+					String summary = null;
+					if (id == 0) { // didn't work
+						// try "msbp_view_summary" then
+						id = a.getResourceId(R.styleable.SeekBarPreference_msbp_view_summary, 0);
+						if (id == 0) {// no reference supplied
+							// try "msbp_view_summary" for string then
+							summary = a.getString(R.styleable.SeekBarPreference_msbp_view_summary);
+							if (TextUtils.isEmpty(summary)) { //didn't work
+								// try "android:summary" for string then
+								summary = attrs.getAttributeValue(NS_ANDROID, "summary");
+							}
+						}
+					}
+					// prob. modified value, another branch, but not "else"!
+					if (id != 0) {
+						// ok, we've got a reference
+						summary = null;
+						String summaryResType = context.getResources().getResourceTypeName(id);
+						if (!summaryResType.equalsIgnoreCase("plurals")) {
+							// but it's not plural resource!
+							if (summaryResType.equalsIgnoreCase("string"))// ok, it's string
+								summary = context.getResources().getString(id);
+							// otherwise -- stick to summary = null and summaryResId = 0.
+						}
+					}
+					summaryPluralResId = TextUtils.isEmpty(summary) ? id : 0;
+					this.summary = summary;
+				}
+			}
+			finally {
+				a.recycle();
+			}
+		}
+	}
+
+	private boolean isFormatString(String s) {
+		boolean result = (s != null) && FORMAT_PATTERN.matcher(s).matches();
+		if (DEBUG) Log.d(TAG, '\"' + s + "\" is" + (result ? "" : " not") + " a format string, for sure.");
+		return result;
+	}
+
+
+	void onBind(View view) {
+
+		if (isView) {
+			titleView = view.findViewById(android.R.id.title);
+			summaryView = view.findViewById(android.R.id.summary);
+
+			titleView.setText(title);
+			summaryView.setText(summary);
+		}
+
+		view.setClickable(false);
+
+		seekBarView = view.findViewById(R.id.seekbar);
+		valueView = view.findViewById(R.id.seekbar_value);
+
+		setMaxValue(maxValue);
+		seekBarView.setOnSeekBarChangeListener(this);
+
+		setCurrentValue(currentValue);
+		bindCurrentValueToView();
+
+		bottomLineView = view.findViewById(R.id.bottom_line);
+		valueHolderView = view.findViewById(R.id.value_holder);
+
+		setDialogEnabled(dialogEnabled);
+		setEnabled(isEnabled(), true);
+	}
+
+	private void bindCurrentValueToView() {
+		CharSequence text;
+		if (unitIsFormat) {
+			if (isUsingPluralsForUnits()) {
+				text = context.getResources().getQuantityString(unitPluralsResId, currentValue, currentValue);
+			} else text = String.format(unit, currentValue);
+		} else if (!TextUtils.isEmpty(unit))
+			text = currentValue + unit;
+		else text = Integer.toString(currentValue);
+		valueView.setText(text);
+	}
+
+	@Override
+	public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+		int newValue = progressToValue(progress);
+
+		if (changeValueListener != null) {
+			if (!changeValueListener.onChange(newValue)) {
+				return;
+			}
+		}
+		bindValue(newValue);
+	}
+
+	@Override
+	public void onStartTrackingTouch(SeekBar seekBar) {
+	}
+
+	@Override
+	public void onStopTrackingTouch(SeekBar seekBar) {
+		setCurrentValue(currentValue);
+		bindCurrentValueToView();
+	}
+
+	@Override
+	public void onClick(final View v) {
+		new CustomValueDialog(context, dialogStyle, minValue, maxValue, currentValue)
+				.setPersistValueListener(new PersistValueListener() {
+					@Override
+					public boolean persistInt(int value) {
+						setCurrentValue(value);
+						seekBarView.setOnSeekBarChangeListener(null);
+						seekBarView.setProgress(valueToProgress(currentValue));
+						seekBarView.setOnSeekBarChangeListener(PreferenceControllerDelegate.this);
+
+						bindCurrentValueToView();
+						return true;
+					}
+				})
+				.show();
+	}
+
+
+	String getTitle() {
+		return title;
+	}
+
+	void setTitle(String title) {
+		this.title = title;
+		if (titleView != null) {
+			titleView.setText(title);
+		}
+	}
+
+	String getSummary() {
+		return summary;
+	}
+
+	void setSummary(String summary) {
+		this.summary = summary;
+		if (seekBarView != null) {
+			summaryView.setText(summary);
+		}
+	}
+
+	boolean isEnabled() {
+		if (!isView && viewStateListener != null) {
+			return viewStateListener.isEnabled();
+		} else return isEnabled;
+	}
+
+	void setEnabled(boolean enabled, boolean viewsOnly) {
+		if (DEBUG) Log.d(TAG, "setEnabled = " + enabled);
+		isEnabled = enabled;
+
+		if (viewStateListener != null && !viewsOnly) {
+			viewStateListener.setEnabled(enabled);
+		}
+
+		if (seekBarView != null) { //theoretically might not always work
+			if (DEBUG) Log.d(TAG, "view is disabled!");
+			seekBarView.setEnabled(enabled);
+			valueView.setEnabled(enabled);
+			valueHolderView.setClickable(enabled);
+			valueHolderView.setEnabled(enabled);
+
+			bottomLineView.setEnabled(enabled);
+
+			if (isView) {
+				titleView.setEnabled(enabled);
+				summaryView.setEnabled(enabled);
+			}
+		}
+
+	}
+
+	void setEnabled(boolean enabled) {
+		setEnabled(enabled, false);
+	}
+
+	int getMaxValue() {
+		return maxValue;
+	}
+
+	void setMaxValue(int maxValue) {
+		this.maxValue = maxValue;
+
+		if (seekBarView != null) {
+			/*if (minValue <= 0 && maxValue >= 0) {
+			} else {
+				seekBarView.setMax(maxValue / interval);
+			}*/
+			seekMaxValue = valueToProgress(maxValue);
+			seekBarView.setMax(seekMaxValue);
+
+			seekBarView.setProgress(valueToProgress(currentValue));
+		}
+	}
+
+	private int valueToProgress(int value) {
+		if (value >= maxValue) return seekMaxValue;
+		if (value <= minValue) return 0;
+		return (value - minValue) / interval;
+	}
+
+	private int progressToValue(int progress) {
+		if (progress >= seekMaxValue) return maxValue;
+		if (progress <= 0) return minValue;
+		return progress * interval + minValue;
+	}
+
+	int getMinValue() {
+		return minValue;
+	}
+
+	public void setMinValue(int minValue) {
+		this.minValue = minValue;
+		setMaxValue(maxValue);
+	}
+
+	int getInterval() {
+		return interval;
+	}
+
+	void setInterval(int interval) {
+		this.interval = interval;
+	}
+
+	int getCurrentValue() {
+		return currentValue;
+	}
+
+	private void bindValue(int value) {
+		setCurrentValue(value);
+		bindCurrentValueToView();
+	}
+
+	void setCurrentValue(int value) {
+		if (value < minValue) value = minValue;
+		if (value > maxValue) value = maxValue;
+
+		if (changeValueListener != null) {
+			if (!changeValueListener.onChange(value)) {
+				return;
+			}
+		}
+		currentValue = value;
+		if (seekBarView != null)
+			seekBarView.setProgress(valueToProgress(currentValue));
+
+		if (persistValueListener != null) {
+			persistValueListener.persistInt(value);
+		}
+	}
+
+	public boolean isUsingPluralsForUnits() {
+		return unitPluralsResId != 0;
+	}
+
+	@Nullable
+	String getUnit() {
+		return unit;
+	}
+
+	public void setUnit(String unit) {
+		if (Character.isWhitespace(unit.charAt(0)))
+			this.unit = unit;
+		else
+			this.unit = ' ' + unit;
+
+		unitIsFormat = isFormatString(unit);
+	}
+
+	public boolean isUnitAFormat() {
+		return unitIsFormat;
+	}
+
+	@PluralsRes
+	int getUnitPluralsId() {
+		return unitPluralsResId;
+	}
+
+	/**
+	 * @param pluralsId id of resource that specifies plurals for this unit
+	 */
+	void setUnitPlurals(@PluralsRes int pluralsId) {
+		if (!context.getResources().getResourceTypeName(pluralsId).equalsIgnoreCase("plurals"))
+			throw new IllegalArgumentException("Specified resource is not plural!");
+
+		unitPluralsResId = pluralsId;
+		bindCurrentValueToView();
+	}
+
+	boolean isDialogEnabled() {
+		return dialogEnabled;
+	}
+
+	void setDialogEnabled(boolean dialogEnabled) {
+		this.dialogEnabled = dialogEnabled;
+
+		if (valueHolderView != null && bottomLineView != null) {
+			valueHolderView.setOnClickListener(dialogEnabled ? this : null);
+			valueHolderView.setClickable(dialogEnabled);
+			bottomLineView.setVisibility(dialogEnabled ? View.VISIBLE : View.INVISIBLE);
+		}
+	}
+
+	void setDialogStyle(int dialogStyle) {
+		this.dialogStyle = dialogStyle;
+	}
 }

--- a/library/src/main/java/com/pavelsikun/seekbarpreference/SeekBarPreference.java
+++ b/library/src/main/java/com/pavelsikun/seekbarpreference/SeekBarPreference.java
@@ -108,11 +108,11 @@ public class SeekBarPreference extends Preference implements View.OnClickListene
     }
 
     public String getMeasurementUnit() {
-        return controllerDelegate.getMeasurementUnit();
+        return controllerDelegate.getUnit();
     }
 
     public void setMeasurementUnit(String measurementUnit) {
-        controllerDelegate.setMeasurementUnit(measurementUnit);
+        controllerDelegate.setUnit(measurementUnit);
     }
 
     public boolean isDialogEnabled() {

--- a/library/src/main/java/com/pavelsikun/seekbarpreference/SeekBarPreferenceCompat.java
+++ b/library/src/main/java/com/pavelsikun/seekbarpreference/SeekBarPreferenceCompat.java
@@ -109,11 +109,11 @@ public class SeekBarPreferenceCompat extends Preference implements View.OnClickL
     }
 
     public String getMeasurementUnit() {
-        return controllerDelegate.getMeasurementUnit();
+        return controllerDelegate.getUnit();
     }
 
     public void setMeasurementUnit(String measurementUnit) {
-        controllerDelegate.setMeasurementUnit(measurementUnit);
+        controllerDelegate.setUnit(measurementUnit);
     }
 
     public boolean isDialogEnabled() {

--- a/library/src/main/java/com/pavelsikun/seekbarpreference/SeekBarPreferenceView.java
+++ b/library/src/main/java/com/pavelsikun/seekbarpreference/SeekBarPreferenceView.java
@@ -113,11 +113,11 @@ public class SeekBarPreferenceView extends FrameLayout implements View.OnClickLi
     }
 
     public String getMeasurementUnit() {
-        return controllerDelegate.getMeasurementUnit();
+        return controllerDelegate.getUnit();
     }
 
     public void setMeasurementUnit(String measurementUnit) {
-        controllerDelegate.setMeasurementUnit(measurementUnit);
+        controllerDelegate.setUnit(measurementUnit);
     }
 
     public void setOnValueSelectedListener(PersistValueListener persistValueListener) {

--- a/library/src/main/res/layout/seekbar_view_layout.xml
+++ b/library/src/main/res/layout/seekbar_view_layout.xml
@@ -56,28 +56,13 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:gravity="right"
-                    android:orientation="horizontal">
                     <TextView
                         android:id="@+id/seekbar_value"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:paddingRight="4dp"
                         android:textSize="14sp"
                         android:textColor="?android:attr/textColorSecondary"
                         android:maxLines="1"/>
-                    <TextView
-                        android:id="@+id/measurement_unit"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textSize="14sp"
-                        android:maxLines="1"
-                        android:ellipsize="marquee"
-                        android:textColor="?android:attr/textColorSecondary"/>
-                </LinearLayout>
 
                 <FrameLayout
                     android:id="@+id/bottom_line"

--- a/library/src/main/res/layout/value_selector_dialog.xml
+++ b/library/src/main/res/layout/value_selector_dialog.xml
@@ -12,7 +12,7 @@
         android:paddingBottom="18dp"
         android:paddingTop="18dp">
 
-        <ImageView
+        <android.support.v7.widget.AppCompatImageView
             android:id="@+id/dialog_icon"
             android:layout_width="42dp"
             android:layout_height="42dp"
@@ -77,28 +77,6 @@
             android:layout_weight="1"
             android:textSize="18sp"
             android:gravity="center"/>
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="right"
-        android:orientation="horizontal">
-
-        <Button
-            android:id="@+id/btn_cancel"
-            style="?android:borderlessButtonStyle"
-            android:text="@android:string/cancel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-
-        <Button
-            android:id="@+id/btn_apply"
-            style="?android:borderlessButtonStyle"
-            android:text="@string/apply"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-
     </LinearLayout>
 
 </LinearLayout>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -6,14 +6,14 @@
         <attr name="msbp_measurementUnit" format="reference|string"/>
         <attr name="msbp_dialogEnabled" format="reference|boolean"/>
         <attr name="msbp_dialogStyle" format="reference"/>
+        <attr name="msbp_dialogCancel" format="reference|string"/>
+        <attr name="msbp_dialogOk" format="reference|string"/>
+        <attr name="msbp_dialogTitle" format="reference|string"/>
 
         <!--next ones should be used only with view!-->
         <attr name="msbp_view_title" format="reference|string"/>
         <attr name="msbp_view_summary" format="reference|string"/>
         <attr name="msbp_view_defaultValue" format="reference|integer"/>
         <attr name="msbp_view_enabled" format="reference|boolean"/>
-
-        <!--not implemented yet-->
-        <!--<attr name="msbp_dialogStyle" format="reference"/>-->
     </declare-styleable>
 </resources>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -5,6 +5,7 @@
         <attr name="msbp_interval" format="reference|integer"/>
         <attr name="msbp_measurementUnit" format="reference|string"/>
         <attr name="msbp_dialogEnabled" format="reference|boolean"/>
+        <attr name="msbp_dialogStyle" format="reference"/>
 
         <!--next ones should be used only with view!-->
         <attr name="msbp_view_title" format="reference|string"/>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -3,5 +3,4 @@
     <string name="errors.must_be_between">Must be between</string>
     <string name="errors.and">And</string>
     <string name="enter_custom_value">Enter custom value</string>
-    <string name="apply">apply</string>
 </resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -3,5 +3,8 @@
     <style name="MSB_Dialog_Default" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="colorPrimary">@color/color_dialog</item>
         <item name="colorAccent">@color/color_dialog</item>
+        <item name="msbp_dialogCancel">@android:string/cancel</item>
+        <item name="msbp_dialogOk">@android:string/ok</item>
+        <item name="msbp_dialogTitle">@string/enter_custom_value</item>
     </style>
 </resources>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "com.pavelsikun.seekbarpreference.sample"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,15 +1,16 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "com.pavelsikun.seekbarpreference.sample"
-        minSdkVersion 7
-        targetSdkVersion 23
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 6
         versionName "6.0"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {
@@ -24,7 +25,7 @@ dependencies {
     //    for your projects use:
 //        compile 'com.pavelsikun:material-seekbar-preference:2.3.0'
 
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:cardview-v7:23.4.0'
-    compile 'com.android.support:preference-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support:cardview-v7:26.1.0'
+    compile 'com.android.support:preference-v7:26.1.0'
 }

--- a/sample/src/main/res/layout/view_demo.xml
+++ b/sample/src/main/res/layout/view_demo.xml
@@ -25,12 +25,12 @@
                 android:layout_height="match_parent"
                 android:background="?attr/selectableItemBackground"
                 android:orientation="horizontal">
-                <ImageView
+                <android.support.v7.widget.AppCompatImageView
                     android:layout_width="48dp"
                     android:padding="4dp"
                     android:layout_marginLeft="8dp"
                     android:layout_height="match_parent"
-                    android:src="@drawable/settings_box"
+                    app:srcCompat="@drawable/settings_box"
                     android:scaleType="fitCenter"/>
                 <TextView
                     android:layout_width="wrap_content"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -2,4 +2,12 @@
     <string name="hello_world">Hello world!</string>
     <string name="action_settings">Settings</string>
     <string name="title_activity_main">SeekBarPreference Lib Sample :D</string>
+    <plurals name="plural_bananas" >
+        <item quantity="zero">zero (%d)</item>
+        <item quantity="one">one (%d)</item>
+        <item quantity="two">two (%d)</item>
+        <item quantity="few">few (%d)</item>
+        <item quantity="many">many (%d)</item>
+        <item quantity="other">other (%d)</item>
+    </plurals>
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -12,12 +12,14 @@
     <style name="Widget.Toolbar" parent="@style/Widget.AppCompat.Toolbar">
         <item name="android:background">@color/primary</item>
     </style>
+
     <style name="Theme.Application.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
 
     <style name="Theme.Application.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
     <style name="Theme.Application.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
 
@@ -25,4 +27,9 @@
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
     </style>
 
+    <style name="MSB_Dialog_Default.Freaky">
+        <item name="msbp_dialogCancel">I don't know</item>
+        <item name="msbp_dialogOk">Answer"</item>
+        <item name="msbp_dialogTitle">How much bananas has the monkey thrown at you?</item>
+    </style>
 </resources>

--- a/sample/src/main/res/xml/pref_general.xml
+++ b/sample/src/main/res/xml/pref_general.xml
@@ -5,10 +5,13 @@
         android:defaultValue="0"
         android:key="pr1s"
         android:title="SeekbarPreference Plurals"
+        sample:msbp_dialogStyle="@style/MSB_Dialog_Default.Freaky"
 
         sample:msbp_interval="1"
         sample:msbp_maxValue="10"
         sample:msbp_measurementUnit="@plurals/plural_bananas"
+
+
         sample:msbp_minValue="-10" />
 
     <com.pavelsikun.seekbarpreference.SeekBarPreference

--- a/sample/src/main/res/xml/pref_general.xml
+++ b/sample/src/main/res/xml/pref_general.xml
@@ -2,6 +2,16 @@
     xmlns:sample="http://schemas.android.com/apk/res-auto">
 
     <com.pavelsikun.seekbarpreference.SeekBarPreference
+        android:defaultValue="0"
+        android:key="pr1s"
+        android:title="SeekbarPreference Plurals"
+
+        sample:msbp_interval="1"
+        sample:msbp_maxValue="10"
+        sample:msbp_measurementUnit="@plurals/plural_bananas"
+        sample:msbp_minValue="-10" />
+
+    <com.pavelsikun.seekbarpreference.SeekBarPreference
         android:defaultValue="600"
         android:key="pr1"
         android:title="SeekbarPreference 1"


### PR DESCRIPTION
So long, and thanks for all the Gingerbread.

`msbp_measurementUnit` can now receive string/plurals reference, if it's a string it can be formatted.

Non-format strings are appended to the right of the value

Plurals must be format strings with single argument, supported substitutions: %d, %h, %s.

Picker dialog cancel and ok buttons are customizable by style, attributes `msbp_dialogCancel` and `msbp_dialogOk`.

Picker dialog title can be customized by `msbp_dialogTitle` attribute.